### PR TITLE
Use separated logos for apps

### DIFF
--- a/webapp/deploy.sh
+++ b/webapp/deploy.sh
@@ -1,4 +1,11 @@
 TARGET_DIRECTORY=../../YoQuieroAyudar.github.io/
+HOST="api.microhuchasolidaria.org"
+USER="deploy"
 echo "Copying files to "$TARGET_DIRECTORY
 cp -r dist/* $TARGET_DIRECTORY
 echo 'Done copying'
+echo 'run sync command in the server'
+ssh $USER@HOST << EOF
+  bash ~/sync-all-web.sh
+EOF
+echo "done syncing the server web apps"

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -7,10 +7,10 @@
     <link rel="manifest" href="./manifest.json">
 
     <meta property="og:title" content="IWantToHelp">
-    <meta property="og:image" content="https://yoquieroayudar.github.io/launcher-icon-512.png">
+    <meta property="og:image" content="https://yoquieroayudar.github.io/logos/launcher-icon-512.png">
 
     <meta property="og:title" content="IWantToHelp">
-    <meta property="og:image" content="https://yoquieroayudar.github.io/launcher-icon-512.png">
+    <meta property="og:image" content="https://yoquieroayudar.github.io/logos/launcher-icon-512.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@website-username">
 

--- a/webapp/src/manifest.json
+++ b/webapp/src/manifest.json
@@ -3,27 +3,27 @@
   "display": "standalone",
   "icons": [
     {
-      "src": "launcher-icon.png",
+      "src": "logos/launcher-icon.png",
       "sizes": "48x48",
       "type": "image/png"
     },
     {
-      "src": "launcher-icon-96.png",
+      "src": "logos/launcher-icon-96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "launcher-icon-144.png",
+      "src": "logos/launcher-icon-144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "launcher-icon-192.png",
+      "src": "logos/launcher-icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "launcher-icon-256.png",
+      "src": "logos/launcher-icon-256.png",
       "sizes": "256x256",
       "type": "image/png"
     }

--- a/webapp/sync-all-web.sh
+++ b/webapp/sync-all-web.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# variable
+BASE_DIR=/var/www
+JVA=$BASE_DIR/web-jva
+MHS=$BASE_DIR/web-mhs
+IWTH=$BASE_DIR/web-iwth
+REPO_DIR=YoQuieroAyudar.github.io
+REPO_USER=YoQuieroAyudar
+REMOTE_REPO=https://github.com/$REPO_USER/$REPO_DIR.git
+
+echo "syncing JVA in "$JVA
+cd $JVA
+cd $REPO_DIR
+git pull
+cp -r jva-logos/* logos
+cp -r jva-manifest/* manifest
+
+echo "syncing MHS in "$MHS
+cd $MHS
+cd $REPO_DIR
+git pull
+cp -r mhs-logos/* logos
+cp -r mhs-manifest/* manifest
+
+echo "syncing IWTH in "$IWTH
+cd $IWTH
+cd $REPO_DIR
+git pull
+cp -r iwth-logos/* logos
+cp -r iwth-manifest/* manifest


### PR DESCRIPTION
- added sync command on the server
- moved the current app logos in the logos
- updated the sync-all-web script to include the app dependent logos and manifest copying
- 